### PR TITLE
add options for Netbox v3.2

### DIFF
--- a/.github/workflows/netbox.yml
+++ b/.github/workflows/netbox.yml
@@ -22,6 +22,7 @@ jobs:
           - rockylinux8
           - ubuntu2004
         netbox:
+          - v3.2-beta1
           - v3.1.8
           - v3.1.7
           - v3.0.12

--- a/.github/workflows/netbox.yml
+++ b/.github/workflows/netbox.yml
@@ -18,7 +18,6 @@ jobs:
       matrix:
         distro:
           - amazonlinux2
-          - centos8
           - rockylinux8
           - ubuntu2004
         netbox:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: Netbox
 
 [![Netbox](
-https://img.shields.io/badge/Netbox-v3.1.8-blue)](https://github.com/netbox-community/netbox)
+https://img.shields.io/badge/Netbox-v3.2-beta1-blue)](https://github.com/netbox-community/netbox)
 [![CI](https://github.com/jvoss/ansible-role-netbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jvoss/ansible-role-netbox/actions/workflows/ci.yml)
 [![Netbox](https://github.com/jvoss/ansible-role-netbox/actions/workflows/netbox.yml/badge.svg)](https://github.com/jvoss/ansible-role-netbox/actions/workflows/netbox.yml)
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-jvoss.netbox-blue.svg)](https://galaxy.ansible.com/jvoss/netbox)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ansible Role: Netbox
 
 [![Netbox](
-https://img.shields.io/badge/Netbox-v3.2-beta1-blue)](https://github.com/netbox-community/netbox)
+https://img.shields.io/badge/Netbox-v3.2_beta1-blue)](https://github.com/netbox-community/netbox)
 [![CI](https://github.com/jvoss/ansible-role-netbox/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/jvoss/ansible-role-netbox/actions/workflows/ci.yml)
 [![Netbox](https://github.com/jvoss/ansible-role-netbox/actions/workflows/netbox.yml/badge.svg)](https://github.com/jvoss/ansible-role-netbox/actions/workflows/netbox.yml)
 [![Ansible Galaxy](https://img.shields.io/badge/galaxy-jvoss.netbox-blue.svg)](https://galaxy.ansible.com/jvoss/netbox)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,6 +131,22 @@ netbox_base_path:
 # Note: Moved to Dynamic Configuration (see netbox_override_dynamic_config)
 netbox_changelog_retention: 90
 
+# Introduced in Netbox v3.2
+# See: https://github.com/netbox-community/netbox/issues/8054
+#
+# Custom choices can be now added to most object status fields in NetBox.
+# This is done by defining the FIELD_CHOICES configuration parameter to map
+# field identifiers to an iterable of custom choices and (optionally) colors.
+# These choices are populated automatically when NetBox initializes.
+# For example, the following configuration will add three custom choices for
+# the site status field, each with a designated color:
+netbox_field_choices: {
+#   dcim.Site.status:
+#     - ['foo', 'Foo', 'red'],
+#     - ['bar', 'Bar', 'green'],
+#     - ['baz', 'Baz', 'blue']
+}
+
 # API Cross-Origin Resource Sharing (CORS) settings. If CORS_ORIGIN_ALLOW_ALL is set to
 # True, all origins will be allowed. Otherwise, define a list of allowed origins using
 # either CORS_ORIGIN_WHITELIST or CORS_ORIGIN_REGEX_WHITELIST. For more information, see

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -139,7 +139,7 @@ netbox_changelog_retention: 90
 # administrators can now define default preferences for all users with the
 # DEFAULT_USER_PREFERENCES configuration parameter. For example, this can be
 # used to define the columns which appear by default in a table:
-# netbox_default_user_preferences:
+#netbox_default_user_preferences:
 #   tables:
 #     IPAddressTable:
 #       columns:
@@ -157,12 +157,11 @@ netbox_changelog_retention: 90
 # These choices are populated automatically when NetBox initializes.
 # For example, the following configuration will add three custom choices for
 # the site status field, each with a designated color:
-netbox_field_choices: {
+#netbox_field_choices:
 #   dcim.Site.status:
 #     - ['foo', 'Foo', 'red'],
 #     - ['bar', 'Bar', 'green'],
 #     - ['baz', 'Baz', 'blue']
-}
 
 # API Cross-Origin Resource Sharing (CORS) settings. If CORS_ORIGIN_ALLOW_ALL is set to
 # True, all origins will be allowed. Otherwise, define a list of allowed origins using

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -131,7 +131,24 @@ netbox_base_path:
 # Note: Moved to Dynamic Configuration (see netbox_override_dynamic_config)
 netbox_changelog_retention: 90
 
-# Introduced in Netbox v3.2
+# Netbox >3.2
+# See: https://github.com/netbox-community/netbox/issues/7759
+#
+# A robust new mechanism for managing user preferences is included in this
+# release. The user preferences form has been improved for better usability, and
+# administrators can now define default preferences for all users with the
+# DEFAULT_USER_PREFERENCES configuration parameter. For example, this can be
+# used to define the columns which appear by default in a table:
+# netbox_default_user_preferences:
+#   tables:
+#     IPAddressTable:
+#       columns:
+#         - address
+#         - status
+#         - created
+#         - description
+
+# Netbox >3.2
 # See: https://github.com/netbox-community/netbox/issues/8054
 #
 # Custom choices can be now added to most object status fields in NetBox.

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -9,6 +9,7 @@
     name: "{{ item }}"
     state: present
   loop:
+    - git
     - python3.8
     - python3-pip
     - python3.8-venv

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -9,6 +9,7 @@
     state: present
   loop:
     - gcc
+    - git
     - python38
     - python38-devel
     - python3-pip

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -111,6 +111,10 @@ CUSTOM_VALIDATORS = {
 
 DEBUG = {{ netbox_debug }}
 
+{% if netbox_default_user_preferences | length > 0 %}
+DEFAULT_USER_PREFERENCES = {{ netbox_default_user_preferences|to_json }}
+{% endif %}
+
 EMAIL = {
     'SERVER': '{{ netbox_email.server }}',
     'PORT': {{ netbox_email.port }},
@@ -136,7 +140,7 @@ EXEMPT_VIEW_PERMISSIONS = []
 FIELD_CHOICES = {
 {% for key,values in netbox_field_choices.items() %}
     {{ key }}: (
-        ({{ values|join(', ') }}),
+        ('{{ values| map('quote') | join('\',\'') }}'),
     )
 {% endfor %}
 }

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -111,7 +111,7 @@ CUSTOM_VALIDATORS = {
 
 DEBUG = {{ netbox_debug }}
 
-{% if netbox_default_user_preferences | length > 0 %}
+{% if netbox_default_user_preferences is defined %}
 DEFAULT_USER_PREFERENCES = {{ netbox_default_user_preferences|to_json }}
 {% endif %}
 
@@ -136,7 +136,7 @@ EXEMPT_VIEW_PERMISSIONS = {{ netbox_exempt_view_permissions|to_json }}
 EXEMPT_VIEW_PERMISSIONS = []
 {% endif %}
 
-{% if netbox_field_choices|length > 0 %}
+{% if netbox_field_choices is defined %}
 FIELD_CHOICES = {
 {% for key,values in netbox_field_choices.items() %}
     '{{ key }}': (

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -132,6 +132,16 @@ EXEMPT_VIEW_PERMISSIONS = {{ netbox_exempt_view_permissions|to_json }}
 EXEMPT_VIEW_PERMISSIONS = []
 {% endif %}
 
+{% if netbox_field_choices|length > 0 %}
+FIELD_CHOICES = {
+{% for key,values in netbox_field_choices.items() %}
+    {{ key }}: (
+        ({{ values|join(', ') }}),
+    )
+{% endfor %}
+}
+{% endif %}
+
 {% if netbox_override_dynamic_config %}
 GRAPHQL_ENABLED = {{ netbox_graphql_enabled }}
 {% endif %}

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -140,7 +140,7 @@ EXEMPT_VIEW_PERMISSIONS = []
 FIELD_CHOICES = {
 {% for key,values in netbox_field_choices.items() %}
     {{ key }}: (
-        ('{{ values| map('quote') | join('\',\'') }}'),
+        ('{{ values| join('\',\'') }}'),
     )
 {% endfor %}
 }

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -139,7 +139,7 @@ EXEMPT_VIEW_PERMISSIONS = []
 {% if netbox_field_choices|length > 0 %}
 FIELD_CHOICES = {
 {% for key,values in netbox_field_choices.items() %}
-    {{ key }}: (
+    '{{ key }}': (
         ('{{ values| join('\',\'') }}'),
     )
 {% endfor %}


### PR DESCRIPTION
Introduces support for upcoming [Netbox v3.2](https://github.com/netbox-community/netbox/releases/tag/v3.2-beta1). 

New configuration options described in `defaults.yml`:
- `netbox_default_user_preferences` (DEFAULT_USER_PREFERENCES)
- `netbox_field_choices` (FIELD_CHOICES)

