### PR TITLE
add missing NAPALM plugin installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -278,6 +278,13 @@ netbox_metrics_enabled: False
 # Credentials that Netbox will uses to authenticate to devices when connecting
 # via NAPALM.
 # Note: Moved to Dynamic Configuration (see netbox_override_dynamic_config)
+# Define an empty `netbox_napalm` dict in your variables to install the NAPALM
+# libraries (when using dynamic configuration)
+#
+# netbox_napalm:
+#
+# pre Netbox 3.1:
+#
 # netbox_napalm:
 #   username: ''
 #   password: ''

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -278,15 +278,15 @@ netbox_metrics_enabled: False
 # Credentials that Netbox will uses to authenticate to devices when connecting
 # via NAPALM.
 # Note: Moved to Dynamic Configuration (see netbox_override_dynamic_config)
-netbox_napalm:
-  username: ''
-  password: ''
-  timeout: 30 # NAPALM timeout (in seconds). (Default: 30)
+# netbox_napalm:
+#   username: ''
+#   password: ''
+#   timeout: 30 # NAPALM timeout (in seconds). (Default: 30)
 
-  # NAPALM optional arguments
-  # (see https://napalm.readthedocs.io/en/latest/support/#optional-arguments).
-  # Arguments must be provided as a dictionary.
-  args: {}
+#   # NAPALM optional arguments
+#   # (see https://napalm.readthedocs.io/en/latest/support/#optional-arguments).
+#   # Arguments must be provided as a dictionary.
+#   args: {}
 
 # Determine how many objects to display per page within a list. (Default: 50)
 # Note: Moved to Dynamic Configuration (see netbox_override_dynamic_config)

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
     mode: '0644'
     create: yes
 
-- name: configure | add the NAPALM to local_requirements.txt
+- name: configure | add NAPALM to local_requirements.txt
   ansible.builtin.lineinfile:
     path: "{{ netbox_current_path }}/local_requirements.txt"
     line: "napalm"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,6 +10,16 @@
     mode: '0644'
     create: yes
 
+- name: configure | add the NAPALM to local_requirements.txt
+  ansible.builtin.lineinfile:
+    path: "{{ netbox_current_path }}/local_requirements.txt"
+    line: "napalm"
+    regexp: "^napalm"
+    owner: "{{ netbox_user }}"
+    mode: '0644'
+    create: yes
+  when: netbox_napalm is defined
+
 - name: configure | generate django secret key
   ansible.builtin.command: "python3 {{ netbox_current_path }}/netbox/generate_secret_key.py"
   register: netbox_secret_key_generated


### PR DESCRIPTION
Add NAPALM to the list of packages `local_requirements.txt` installs when `netbox_napalm` is defined in the variables. 

No additional configuration is necessary if the new dynamic configurations are being used in Netbox versions >= v3.1.