### PR TITLE
add support for debian bullseye

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,10 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - focal
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
   galaxy_tags:
     - netbox
     - networking

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -5,6 +5,6 @@ roles:
   - name: geerlingguy.postgresql
     scm: git
     src: 'git+https://github.com/geerlingguy/ansible-role-postgresql'
-    version: 3.1.0
+    version: 3.2.1
 
   - name: geerlingguy.redis

--- a/tasks/install.amazon.yml
+++ b/tasks/install.amazon.yml
@@ -15,14 +15,14 @@
   register: amzn2extras
   changed_when: amzn2extras is failed
   with_items:
-    - python3.8
+    - "{{ python_packages }}"
     - postgresql12
 
 - name: install.amazon | enable required extras
   ansible.builtin.command: "amazon-linux-extras enable {{ item }} "
   become: yes
   with_items:
-    - python3.8
+    - "{{ python_packages }}"
     - postgresql12
   when: not amazon_extras_repo.stat.exists or amzn2extras is failed
 

--- a/tasks/install.debian.yml
+++ b/tasks/install.debian.yml
@@ -10,10 +10,6 @@
     state: present
   loop:
     - git
-    - python3.8
-    - python3-pip
-    - python3.8-venv
-    - python3.8-dev
     - build-essential
     - libxml2-dev
     - libxslt1-dev
@@ -21,6 +17,11 @@
     - libpq-dev
     - libssl-dev
     - zlib1g-dev
+
+- name: install.debian | install required python packages
+  ansible.builtin.apt:
+    name: "{{ python_packages }}"
+    state: present
 
 - name: install.debian | install Git
   ansible.builtin.apt:

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -10,15 +10,17 @@
   loop:
     - gcc
     - git
-    - python38
-    - python38-devel
-    - python3-pip
     - libxml2-devel
     - libxslt-devel
     - libffi-devel
     - libpq-devel
     - openssl-devel
     - redhat-rpm-config
+
+- name: install.redhat | install required python packages
+  ansible.builtin.yum:
+    name: "{{ python_packages }}"
+    state: present
 
 - name: install.redhat | install Git
   ansible.builtin.yum:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+# Variable configuration.
+- include_tasks: variables.yml
+
 - name: Include system packages
   include_tasks: "install.{{ ansible_os_family | lower }}.yml"
   args:

--- a/tasks/superusers.yml
+++ b/tasks/superusers.yml
@@ -20,5 +20,6 @@
     label: "{{ item.username }}"
   changed_when: '"Superuser created successfully." in result.stdout'
   failed_when: >
+    (result.rc != 0) and
     (result.stderr != '') and
     ("CommandError: Error: That username is already taken." not in result.stderr)

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -2,7 +2,7 @@
 - name: upgrade | run the upgrade script
   ansible.builtin.command: "{{ netbox_current_path }}/upgrade.sh"
   environment:
-    PYTHON: python3.8
+    PYTHON: "{{ python_version }}"
   become: yes
   become_method: sudo
   become_user: "{{ netbox_user }}"

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -2,7 +2,7 @@
 - name: upgrade | run the upgrade script
   ansible.builtin.command: "{{ netbox_current_path }}/upgrade.sh"
   environment:
-    PYTHON: "{{ python_version }}"
+    PYTHON: "python{{ python_version | default(__python_version) }}"
   become: yes
   become_method: sudo
   become_user: "{{ netbox_user }}"

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,0 +1,10 @@
+---
+# Variable configuration.
+- name: Include OS-specific variables (Debian).
+  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  when: ansible_os_family == 'Debian'
+
+- name: Define python_packages.
+  ansible.builtin.set_fact:
+    python_packages: "{{ __python_packages | list }}"
+  when: python_packages is not defined

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -18,3 +18,8 @@
   ansible.builtin.set_fact:
     python_packages: "{{ __python_packages | list }}"
   when: python_packages is not defined
+
+- name: Define python_version.
+  ansible.builtin.set_fact:
+    python_version: "{{ __python_version }}"
+  when: python_version is not defined

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -4,6 +4,16 @@
   ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
   when: ansible_os_family == 'Debian'
 
+- name: Include OS-specific variables (RedHat).
+  ansible.builtin.include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  when:
+  - ansible_os_family == 'RedHat'
+  - ansible_distribution != 'Amazon'
+
+- name: Include OS-specific variables (Amazon).
+  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+  when: ansible_distribution == 'Amazon'
+
 - name: Define python_packages.
   ansible.builtin.set_fact:
     python_packages: "{{ __python_packages | list }}"

--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -1,0 +1,2 @@
+---
+__python_packages: python3.8

--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -1,3 +1,4 @@
 ---
 __python_version: "3.8"
-__python_packages: "python{{ python_version | default(__python_version) }}"
+__python_packages:
+  - "python{{ python_version | default(__python_version) }}"

--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -1,2 +1,3 @@
 ---
-__python_packages: python3.8
+__python_version: "3.8"
+__python_packages: "python{{ python_version }}"

--- a/vars/Amazon-2.yml
+++ b/vars/Amazon-2.yml
@@ -1,3 +1,3 @@
 ---
 __python_version: "3.8"
-__python_packages: "python{{ python_version }}"
+__python_packages: "python{{ python_version | default(__python_version) }}"

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,0 +1,6 @@
+---
+__python_packages:
+    - python3.8
+    - python3-pip
+    - python3.8-venv
+    - python3.8-dev

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,7 +1,7 @@
 ---
 __python_version: "3.8"
 __python_packages:
-    - "python{{ python_version }}"
+    - "python{{ python_version | default(__python_version) }}"
     - "python3-pip"
-    - "python{{ python_version }}-venv"
-    - "python{{ python_version }}-dev"
+    - "python{{ python_version | default(__python_version) }}-venv"
+    - "python{{ python_version | default(__python_version) }}-dev"

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,7 +1,10 @@
 ---
-__python_version: "3.8"
+__python_version: "3.7"
+# this is the last supported available version of python on debian 10.
 __python_packages:
     - "python{{ python_version | default(__python_version) }}"
     - "python3-pip"
     - "python{{ python_version | default(__python_version) }}-venv"
     - "python{{ python_version | default(__python_version) }}-dev"
+netbox_version_tag: v3.1.11
+# this is the last supported version of netbox on debian 10.

--- a/vars/Debian-10.yml
+++ b/vars/Debian-10.yml
@@ -1,6 +1,7 @@
 ---
+__python_version: "3.8"
 __python_packages:
-    - python3.8
-    - python3-pip
-    - python3.8-venv
-    - python3.8-dev
+    - "python{{ python_version }}"
+    - "python3-pip"
+    - "python{{ python_version }}-venv"
+    - "python{{ python_version }}-dev"

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,7 +1,7 @@
 ---
 __python_version: "3.9"
 __python_packages:
-    - "python{{ python_version }}"
+    - "python{{ python_version | default(__python_version) }}"
     - "python3-pip"
-    - "python{{ python_version }}-venv"
-    - "python{{ python_version }}-dev"
+    - "python{{ python_version | default(__python_version) }}-venv"
+    - "python{{ python_version | default(__python_version) }}-dev"

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,6 @@
+---
+__python_packages:
+    - python3.9
+    - python3-pip
+    - python3.9-venv
+    - python3.9-dev

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,6 +1,7 @@
 ---
+__python_version: "3.9"
 __python_packages:
-    - python3.9
-    - python3-pip
-    - python3.9-venv
-    - python3.9-dev
+    - "python{{ python_version }}"
+    - "python3-pip"
+    - "python{{ python_version }}-venv"
+    - "python{{ python_version }}-dev"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,0 +1,5 @@
+---
+__python_packages:
+    - python38
+    - python38-devel
+    - python3-pip

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,5 +1,6 @@
 ---
+__python_version: "3.8"
 __python_packages:
-    - python38
-    - python38-devel
-    - python3-pip
+    - "python{{ python_version | replace('.','') }}"
+    - "python{{ python_version | replace('.','') }}-devel"
+    - "python3-pip"

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,6 +1,6 @@
 ---
 __python_version: "3.8"
 __python_packages:
-    - "python{{ python_version | replace('.','') }}"
-    - "python{{ python_version | replace('.','') }}-devel"
+    - "python{{ python_version | default(__python_version) | replace('.','') }}"
+    - "python{{ python_version | default(__python_version) | replace('.','') }}-devel"
     - "python3-pip"

--- a/vars/Ubuntu-20.yml
+++ b/vars/Ubuntu-20.yml
@@ -1,0 +1,6 @@
+---
+__python_packages:
+    - python3.8
+    - python3-pip
+    - python3.8-venv
+    - python3.8-dev

--- a/vars/Ubuntu-20.yml
+++ b/vars/Ubuntu-20.yml
@@ -1,7 +1,7 @@
 ---
 __python_version: "3.8"
 __python_packages:
-    - "python{{ python_version }}"
+    - "python{{ python_version | default(__python_version) }}"
     - "python3-pip"
-    - "python{{ python_version }}-venv"
-    - "python{{ python_version }}-dev"
+    - "python{{ python_version | default(__python_version) }}-venv"
+    - "python{{ python_version | default(__python_version) }}-dev"

--- a/vars/Ubuntu-20.yml
+++ b/vars/Ubuntu-20.yml
@@ -1,6 +1,7 @@
 ---
+__python_version: "3.8"
 __python_packages:
-    - python3.8
-    - python3-pip
-    - python3.8-venv
-    - python3.8-dev
+    - "python{{ python_version }}"
+    - "python3-pip"
+    - "python{{ python_version }}-venv"
+    - "python{{ python_version }}-dev"


### PR DESCRIPTION
Add support for Debian bullseye, which doesn't have python3.8 (only 3.9).
Bumped ansible-role-postgresql version in molecule if we want at some point add debian in tests. This version comes with support for Debian-11.

Feel free to modify the code to adapt to your coding style.

