### PR TITLE
add support for username_is_full_email

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -329,6 +329,7 @@ netbox_remote_auth:
   auto_create_user: True
   default_groups: []
   default_permissions: {}
+  # social_auth_username_is_full_email: false
 
 # This repository is used to check whether there is a new release of NetBox available.
 # Set to None to disable the version check or use the URL below to check for release

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -260,6 +260,10 @@ SOCIAL_AUTH_AZUREAD_OAUTH2_SECRET = '{{ netbox_remote_auth.azuread_oauth2.secret
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = {{ netbox_remote_auth.social_auth_redirect_is_https }}
 {% endif %}
 
+{% if netbox_remote_auth.social_auth_username_is_full_email is defined %}
+SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL = {{ netbox_remote_auth.social_auth_username_is_full_email }}
+{% endif %}
+
 {% if netbox_release_check_url == 'None' %}
 RELEASE_CHECK_URL = None
 {% else %}


### PR DESCRIPTION
This will add a variable to define the usage of the email as a username during the Username generation in the SSO scenario.

some reference here -> https://python-social-auth.readthedocs.io/en/latest/configuration/settings.html

Best
