### PR TITLE
Add fedora37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           # - amazonlinux2
           - centos8
           - debian11
+          - fedora37
           - rockylinux8
           - ubuntu2004
           - ubuntu2204

--- a/.github/workflows/netbox.yml
+++ b/.github/workflows/netbox.yml
@@ -21,6 +21,7 @@ jobs:
           - centos8
           - debian10
           - debian11
+          - fedora37
           - rockylinux8
           - ubuntu2004
           - ubuntu2204

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Tested on the following platforms:
 * CentOS 8
 * Debian Buster (up to v3.1.11)
 * Debian Bullseye
+* Fedora Linux 37
 * Rocky Linux 8 / Red Hat Enterprise Linux (RHEL) 8.2+
 * Ubuntu 20.04
 * Ubuntu 22.04

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,9 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+    - name: Fedora
+      versions:
+        - "37"
     - name: Ubuntu
       versions:
         - focal

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -3,6 +3,17 @@
   ansible.builtin.include_tasks: install.amazon.yml
   when: ansible_distribution == 'Amazon'
 
+- name: install.redhat | install packages missing on Fedora
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - acl
+    - cronie
+    - python3-Django
+  when:
+    - ansible_distribution == 'Fedora'
+
 - name: install.redhat | install required system packages
   ansible.builtin.yum:
     name: "{{ item }}"

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -10,7 +10,7 @@
   loop:
     - acl
     - cronie
-    - python3-Django
+    - python3-django
   when:
     - ansible_distribution == 'Fedora'
 

--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -8,7 +8,13 @@
   ansible.builtin.include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
   when:
   - ansible_os_family == 'RedHat'
+  - ansible_distribution != 'Fedora'
   - ansible_distribution != 'Amazon'
+
+- name: Include OS-specific variables (Fedora).
+  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+  when:
+  - ansible_distribution == 'Fedora'
 
 - name: Include OS-specific variables (Amazon).
   ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"

--- a/vars/Fedora-37.yml
+++ b/vars/Fedora-37.yml
@@ -1,5 +1,5 @@
 ---
-__python_version: "3.11"
+__python_version: "3.10"
 __python_packages:
     - "python{{ python_version | default(__python_version) | replace('.', '') }}"
     - "python3-devel"

--- a/vars/Fedora-37.yml
+++ b/vars/Fedora-37.yml
@@ -1,0 +1,6 @@
+---
+__python_version: "3.11"
+__python_packages:
+    - "python{{ python_version | default(__python_version) | replace('.', '') }}"
+    - "python3-devel"
+    - "python3-pip"


### PR DESCRIPTION
Add Fedora37 variables and adjust loading of variables.

Loading the variables is not really nice, since the existing code uses `ansible_os_family == "RedHat"`, which also matches Fedora. If desired I could rework that to use e.g. `first_found` or similar.