### PR TITLE
REFACTOR tasks/variables.yml: use first_found filter for loading of vars files

### DIFF
--- a/tasks/variables.yml
+++ b/tasks/variables.yml
@@ -1,18 +1,15 @@
 ---
 # Variable configuration.
-- name: Include OS-specific variables (Debian).
-  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
-  when: ansible_os_family == 'Debian'
-
-- name: Include OS-specific variables (RedHat).
-  ansible.builtin.include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
-  when:
-  - ansible_os_family == 'RedHat'
-  - ansible_distribution != 'Amazon'
-
-- name: Include OS-specific variables (Amazon).
-  ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
-  when: ansible_distribution == 'Amazon'
+- name: Include OS-specific variables.
+  ansible.builtin.include_vars: "{{ lookup('ansible.builtin.first_found', first_found_params) }}"
+  vars:
+    first_found_params:
+      files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}.yml"
+      paths:
+        - 'vars'
 
 - name: Define python_packages.
   ansible.builtin.set_fact:


### PR DESCRIPTION
See https://docs.ansible.com/ansible/latest/collections/ansible/builtin/first_found_lookup.html#examples

Not sure if both of the first files are needed, IMHO they both do the same thing (unless Amazon Linux does not have the major_version set properly).