### PR TITLE
Add a regex_search to replace plugin version correctly

### DIFF
--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -3,7 +3,7 @@
   ansible.builtin.lineinfile:
     path: "{{ netbox_current_path }}/local_requirements.txt"
     line: "{{ item.pip }}"
-    regexp: "^{{ item.pip }}"
+    regexp: '^{{ item.pip | regex_search("^[^\d\s<>=]+(?: [^\d\s<>=]+)*") }}'
     owner: "{{ netbox_user }}"
     mode: '0644'
     create: yes


### PR DESCRIPTION
When changing a plugin package with version specifiers, you could end up with duplicate packages in the local_requirements file and it will cause upgrade script to fail. This PR updates the regexp search for lineinfile to match only the plugin name only instead of the version specifiers as well.