### PR TITLE
chore(meta): add RHEL9 to platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,7 @@ galaxy_info:
     - name: EL
       versions:
         - "8"
+        - "9"
     - name: Fedora
       versions:
         - "37"


### PR DESCRIPTION
Add RHEL 9 to supported versions in Ansible Galaxy meta