### PR TITLE
Add custom logging option to Netbox configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tests/*.retry
 /.cache
 /venv
 /.venv
+/.ansible

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "ansible.python.interpreterPath": "/opt/homebrew/bin/python3"
+}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -415,3 +415,7 @@ netbox_time_format:
   short_time: H:i:s
   datetime: N j, Y g:i a
   short_datetime: Y-m-d H:i
+
+# Netbox custom Logging configuration
+# This is a JSON dict with the logging configuration
+netbox_logging_config: {}

--- a/tasks/install.amazon.yml
+++ b/tasks/install.amazon.yml
@@ -27,7 +27,7 @@
   when: not amazon_extras_repo.stat.exists or amzn2extras is failed
 
 - name: install.amazon | install tar
-  ansible.builtin.yum:
+  ansible.builtin.yum: # noqa:fqcn[action-core]
     name: tar
     state: present
   when: netbox_install_method != 'git'

--- a/tasks/install.redhat.yml
+++ b/tasks/install.redhat.yml
@@ -24,7 +24,7 @@
     - ansible_distribution_major_version == '9'
 
 - name: install.redhat | install required system packages
-  ansible.builtin.yum:
+  ansible.builtin.yum: # noqa:fqcn[action-core]
     name: "{{ item }}"
     state: present
   loop:
@@ -38,18 +38,18 @@
     - redhat-rpm-config
 
 - name: install.redhat | install required python packages
-  ansible.builtin.yum:
+  ansible.builtin.yum: # noqa:fqcn[action-core]
     name: "{{ python_packages }}"
     state: present
 
 - name: install.redhat | install Git
-  ansible.builtin.yum:
+  ansible.builtin.yum: # noqa:fqcn[action-core]
     name: git
     state: present
   when: netbox_install_method == 'git'
 
 - name: install.redhat | install system packages for LDAP authentication
-  ansible.builtin.yum:
+  ansible.builtin.yum: # noqa:fqcn[action-core]
     name: "{{ item }}"
     state: present
   loop:

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -186,8 +186,12 @@ INTERNAL_IPS = ('{{netbox_internal_ips|join("', '")}}')
 
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/stable/topics/logging/
+{% if netbox_logging_config != {} %}
+import logging.handlers
+LOGGING = {{ netbox_logging_config|to_json }}
+{% else %}
 LOGGING = {}
-
+{% endif %}
 LOGIN_PERSISTENCE = {{ netbox_logging_persistence }}
 
 LOGIN_REQUIRED = {{ netbox_login_required }}

--- a/templates/configuration.py.j2
+++ b/templates/configuration.py.j2
@@ -192,6 +192,7 @@ LOGGING = {{ netbox_logging_config|to_json }}
 {% else %}
 LOGGING = {}
 {% endif %}
+
 LOGIN_PERSISTENCE = {{ netbox_logging_persistence }}
 
 LOGIN_REQUIRED = {{ netbox_login_required }}


### PR DESCRIPTION
Netbox configuration template lacks the possibility of configuring "LOGGING".
I added a variable that allows setting things up, empty by default.

ansible-lint and molecule don't seem to complain